### PR TITLE
macOS: Fix brew service, wget, poetry not in PATH

### DIFF
--- a/configs/poetry_path.sh
+++ b/configs/poetry_path.sh
@@ -1,2 +1,3 @@
+#! /usr/bin/env bash
 # Add poetry to the CLI path
 export PATH="${HOME}/.local/bin:$PATH"

--- a/configs/poetry_path.sh
+++ b/configs/poetry_path.sh
@@ -1,0 +1,2 @@
+# Add poetry to the CLI path
+export PATH="${HOME}/.local/bin:$PATH"

--- a/install_packages.sh
+++ b/install_packages.sh
@@ -149,7 +149,8 @@ function macos_install() {
     set +o xtrace
   fi
 
-  brew services start redis "postgresql@15"
+  brew services start redis
+  brew services start "postgresql@15"
 
   # This is a workaround for a problem with the 1.3.7 version of xmlsec1. It forces a downgrade to 1.2.7.
   # The Atlas Toy IDP uses xmlsec1 to sign the SAML requests.

--- a/install_packages.sh
+++ b/install_packages.sh
@@ -156,7 +156,7 @@ function macos_install() {
   # The Atlas Toy IDP uses xmlsec1 to sign the SAML requests.
   # https://stackoverflow.com/questions/76805174/getting-key-not-found-with-xmlsec1-on-macos
   local desired_sha="7f35e6ede954326a10949891af2dba47bbe1fc17" tmp_libxmlsec1_path=/tmp/libxmlsec1.rb
-  wget -O "${tmp_libxmlsec1_path}" "https://raw.githubusercontent.com/Homebrew/homebrew-core/${desired_sha}/Formula/libxmlsec1.rb"
+  curl -o "${tmp_libxmlsec1_path}" "https://raw.githubusercontent.com/Homebrew/homebrew-core/${desired_sha}/Formula/libxmlsec1.rb"
   HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install --formula "${tmp_libxmlsec1_path}"
 }
 

--- a/install_python_tools.sh
+++ b/install_python_tools.sh
@@ -106,8 +106,10 @@ function ensure_poetry_installed {
   echo "Installing Poetry."
   # Instructions verbatim from https://python-poetry.org/docs/
   curl --silent --show-error --location https://install.python-poetry.org | python3 -
-  # Use single quote intentionally to disable expansion.
-  echo 'export PATH="~/.local/bin:$PATH' >> ~/.bashrc
+  # Add Poetry Executable to System PATH.
+  mkdir -p "${HOME}/.bashrc.d"
+  [[ ! -f "${HOME}/.bashrc.d/poetry_path.sh" ]] && cp "${INSTALL_PYTHON_TOOLS_HERE}/configs/poetry_path.sh" ~/.bashrc.d/
+  source "${HOME}/.bashrc.d/poetry_path.sh"
 
   # The venv manager takes care of creating venvs, not poetry. This is because Poetry will (by default) put its venvs
   # inside the pyproject.toml project directory, which can cause some issues.

--- a/install_python_tools.sh
+++ b/install_python_tools.sh
@@ -106,6 +106,8 @@ function ensure_poetry_installed {
   echo "Installing Poetry."
   # Instructions verbatim from https://python-poetry.org/docs/
   curl --silent --show-error --location https://install.python-poetry.org | python3 -
+  # Use single quote intentionally to disable expansion.
+  echo 'export PATH="~/.local/bin:$PATH' >> ~/.bashrc
 
   # The venv manager takes care of creating venvs, not poetry. This is because Poetry will (by default) put its venvs
   # inside the pyproject.toml project directory, which can cause some issues.


### PR DESCRIPTION
Change log:
- Fix `brew service` can not take more than two arguments.
- Fix `wget` is not pre-installed in macOS --> Use `curl` instead.
- Fix `poetry` executable is not in `PATH` after install.
