### PR TITLE
Fix bash not loading correct profile, upgrade xmlsec1

### DIFF
--- a/install_packages.sh
+++ b/install_packages.sh
@@ -117,7 +117,6 @@ function macos_install() {
     tmux                      # Shell window management
     vagrant                   # Used to stand up local VMs for development
     vim                       # Newer than system Vim, has python support properly compiled in (required for Black)
-    xmlsec1
   )
   local packages_to_install=()
   for package in "${brew_packages[@]}" ; do
@@ -152,6 +151,13 @@ function macos_install() {
 
   brew services start redis
   brew services start "postgresql@15"
+
+  # # This is a workaround for a problem with the 1.3.7 version of xmlsec1. It forces a downgrade to 1.2.7.
+  # # The Atlas Toy IDP uses xmlsec1 to sign the SAML requests.
+  # # https://stackoverflow.com/questions/76805174/getting-key-not-found-with-xmlsec1-on-macos
+  # local desired_sha="7f35e6ede954326a10949891af2dba47bbe1fc17" tmp_libxmlsec1_path=/tmp/libxmlsec1.rb
+  # curl -o "${tmp_libxmlsec1_path}" "https://raw.githubusercontent.com/Homebrew/homebrew-core/${desired_sha}/Formula/libxmlsec1.rb"
+  # HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install --formula "${tmp_libxmlsec1_path}"
 }
 
 

--- a/install_packages.sh
+++ b/install_packages.sh
@@ -144,20 +144,20 @@ function macos_install() {
   fi
 
   if [[ "${#packages_to_install[@]}" -gt 0 ]]; then
-    set -o xtrace
+    # set -o xtrace
     brew install --overwrite "${packages_to_install[@]}"
-    set +o xtrace
+    # set +o xtrace
   fi
 
   brew services start redis
   brew services start "postgresql@15"
 
-  # This is a workaround for a problem with the 1.3.7 version of xmlsec1. It forces a downgrade to 1.2.7.
-  # The Atlas Toy IDP uses xmlsec1 to sign the SAML requests.
-  # https://stackoverflow.com/questions/76805174/getting-key-not-found-with-xmlsec1-on-macos
-  local desired_sha="7f35e6ede954326a10949891af2dba47bbe1fc17" tmp_libxmlsec1_path=/tmp/libxmlsec1.rb
-  curl -o "${tmp_libxmlsec1_path}" "https://raw.githubusercontent.com/Homebrew/homebrew-core/${desired_sha}/Formula/libxmlsec1.rb"
-  HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install --formula "${tmp_libxmlsec1_path}"
+  # # This is a workaround for a problem with the 1.3.7 version of xmlsec1. It forces a downgrade to 1.2.7.
+  # # The Atlas Toy IDP uses xmlsec1 to sign the SAML requests.
+  # # https://stackoverflow.com/questions/76805174/getting-key-not-found-with-xmlsec1-on-macos
+  # local desired_sha="7f35e6ede954326a10949891af2dba47bbe1fc17" tmp_libxmlsec1_path=/tmp/libxmlsec1.rb
+  # curl -o "${tmp_libxmlsec1_path}" "https://raw.githubusercontent.com/Homebrew/homebrew-core/${desired_sha}/Formula/libxmlsec1.rb"
+  # HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install --formula "${tmp_libxmlsec1_path}"
 }
 
 
@@ -181,6 +181,18 @@ if [[ -d ~/.bashrc.d ]]; then
   done
 fi
 unset rc
+EOF
+  fi
+
+  if [[ ! -f ~/.bash_profile ]]; then
+    # Install skeleton .bashrc if one is not present
+    cat >> ~/.bashrc <<"EOF"
+if [ -n "$BASH_VERSION" ]; then
+    # include .bashrc if it exists
+    if [ -f "$HOME/.bashrc" ]; then
+        . "$HOME/.bashrc"
+    fi
+fi
 EOF
   fi
 

--- a/install_packages.sh
+++ b/install_packages.sh
@@ -117,6 +117,7 @@ function macos_install() {
     tmux                      # Shell window management
     vagrant                   # Used to stand up local VMs for development
     vim                       # Newer than system Vim, has python support properly compiled in (required for Black)
+    xmlsec1
   )
   local packages_to_install=()
   for package in "${brew_packages[@]}" ; do
@@ -151,13 +152,6 @@ function macos_install() {
 
   brew services start redis
   brew services start "postgresql@15"
-
-  # # This is a workaround for a problem with the 1.3.7 version of xmlsec1. It forces a downgrade to 1.2.7.
-  # # The Atlas Toy IDP uses xmlsec1 to sign the SAML requests.
-  # # https://stackoverflow.com/questions/76805174/getting-key-not-found-with-xmlsec1-on-macos
-  # local desired_sha="7f35e6ede954326a10949891af2dba47bbe1fc17" tmp_libxmlsec1_path=/tmp/libxmlsec1.rb
-  # curl -o "${tmp_libxmlsec1_path}" "https://raw.githubusercontent.com/Homebrew/homebrew-core/${desired_sha}/Formula/libxmlsec1.rb"
-  # HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install --formula "${tmp_libxmlsec1_path}"
 }
 
 

--- a/install_packages.sh
+++ b/install_packages.sh
@@ -144,9 +144,9 @@ function macos_install() {
   fi
 
   if [[ "${#packages_to_install[@]}" -gt 0 ]]; then
-    # set -o xtrace
+    set -o xtrace
     brew install --overwrite "${packages_to_install[@]}"
-    # set +o xtrace
+    set +o xtrace
   fi
 
   brew services start redis


### PR DESCRIPTION
This PR includes fixes to:
* Fix `bash` not reading `.bashrc`. I added a script in `.bash_profile` to `source`.bashrc` so that `bash` can read the correct script when starting a new terminal window.
* Fix `openssl@1.1` is disabled problem. `openssl@1.1` is disabled by `homebrew` for security issues. `openssl@1.1` is required by `xmlsec1`. Based on the comments, we have some compatibility issue with 1.3.7, @coverprice can you check is the issue still exist or can we update the version to workaround the `openssl@1.1`?